### PR TITLE
Add hf_hub_download

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,18 @@ git clone https://github.com/beichenzbc/Long-CLIP.git
 cd Long-CLIP
 ```
 
-Then, download the checkpoints of our model [LongCLIP-B](https://huggingface.co/BeichenZhang/LongCLIP-B) and/or [LongCLIP-L](https://huggingface.co/BeichenZhang/LongCLIP-L) and place it under `./checkpoints`
+Then, download the checkpoints of our model [LongCLIP-B](https://huggingface.co/BeichenZhang/LongCLIP-B) and/or [LongCLIP-L](https://huggingface.co/BeichenZhang/LongCLIP-L) as shown below:
 
 ```python
 from model import longclip
 import torch
 from PIL import Image
+from huggingface_hub import hf_hub_download
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
-model, preprocess = longclip.load("./checkpoints/longclip-B.pt", device=device)
+# here we download LongCLIP-L
+filepath = hf_hub_download(repo_id="BeichenZhang/LongCLIP-L", filename="longclip-L.pt")
+model, preprocess = longclip.load(filepath, device=device)
 
 text = longclip.tokenize(["A man is crossing the street with a red car parked nearby.", "A man is driving a car in an urban scene."]).to(device)
 image = preprocess(Image.open("./img/demo.png")).unsqueeze(0).to(device)

--- a/README.md
+++ b/README.md
@@ -39,17 +39,16 @@ This repository is the official implementation of Long-CLIP
 
 Our model is based on [CLIP](https://github.com/openai/CLIP), please prepare environment for CLIP.
 
-
-### how to use
-
-Please first clone our [repo](https://github.com/beichenzbc/Long-CLIP) from github by running the following command.
+Next, clone our [repo](https://github.com/beichenzbc/Long-CLIP) from Github by running the following command.
 
 ```shell
 git clone https://github.com/beichenzbc/Long-CLIP.git
 cd Long-CLIP
 ```
 
-Then, download the checkpoints of our model [LongCLIP-B](https://huggingface.co/BeichenZhang/LongCLIP-B) and/or [LongCLIP-L](https://huggingface.co/BeichenZhang/LongCLIP-L) as shown below:
+### how to use
+
+Then, download the checkpoints of our model [LongCLIP-B](https://huggingface.co/BeichenZhang/LongCLIP-B) and/or [LongCLIP-L](https://huggingface.co/BeichenZhang/LongCLIP-L) from 🤗 Hugging Face as shown below:
 
 ```python
 from model import longclip


### PR DESCRIPTION
Hi @beichenzbc, congrats on getting Long-CLIP accepted to ECCV! Indexed the paper page here: https://huggingface.co/papers/2403.15378.

This PR improves the README by showcasing how to use [`hf_hub_download`](https://huggingface.co/docs/huggingface_hub/en/guides/download#download-a-single-file) to download a checkpoint from the hub.

Note: I've also opened PR's to add model cards:
* https://huggingface.co/BeichenZhang/LongCLIP-L/discussions/3
* https://huggingface.co/BeichenZhang/LongCLIP-L-336px/discussions/1

These link the models to the paper page. Would be great to update the other 2 models as well.

Note: we could also make download stats work for your models, by following this: https://huggingface.co/docs/hub/models-download-stats.

Cheers!

Niels, ML Engineer at HF